### PR TITLE
feat(app): add persistence support for PVC-based volumes

### DIFF
--- a/app/Chart.yaml
+++ b/app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: app
 description: Generic Helm chart for deploying Docker containers
 type: application
-version: 1.0.1
+version: 1.1.0
 appVersion: 'latest'
 annotations:
   artifacthub.io/images: |

--- a/app/templates/deployment.yaml
+++ b/app/templates/deployment.yaml
@@ -98,16 +98,33 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.volumeMounts }}
+          {{- if or .Values.volumeMounts (and .Values.persistence.enabled .Values.persistence.volumes) }}
           volumeMounts:
+            {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- if .Values.persistence.enabled }}
+            {{- range .Values.persistence.volumes }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+            {{- end }}
+            {{- end }}
           {{- end }}
         {{- with .Values.sidecars }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.volumes }}
+      {{- if or .Values.volumes (and .Values.persistence.enabled .Values.persistence.volumes) }}
       volumes:
+        {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- if .Values.persistence.enabled }}
+        {{- range .Values.persistence.volumes }}
+        - name: {{ .name }}
+          persistentVolumeClaim:
+            claimName: {{ include "app.fullname" $ }}-{{ .name }}
+        {{- end }}
+        {{- end }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/app/templates/pvc.yaml
+++ b/app/templates/pvc.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.persistence.enabled }}
+{{- range .Values.persistence.volumes }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "app.fullname" $ }}-{{ .name }}
+  labels:
+    {{- include "app.labels" $ | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .accessMode | default "ReadWriteOnce" }}
+  {{- if .storageClassName }}
+  storageClassName: {{ .storageClassName }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .size | default "1Gi" }}
+{{- end }}
+{{- end }}

--- a/app/values.yaml
+++ b/app/values.yaml
@@ -112,7 +112,18 @@ autoscaling:
   maxReplicas: 10
   targetCPUUtilizationPercentage: 80
 
-# Storage
+# Persistence — managed PVCs created from values
+# Each volume entry creates a PersistentVolumeClaim and wires a volumeMount + volume
+persistence:
+  enabled: false
+  volumes: []
+    # - name: data
+    #   mountPath: /var/data
+    #   size: 10Gi
+    #   storageClassName: fast-ssd   # optional — omit to use cluster default
+    #   accessMode: ReadWriteOnce    # ReadWriteOnce | ReadWriteMany | ReadOnlyMany
+
+# Storage — raw volume/volumeMount passthrough (advanced)
 volumes: []
 volumeMounts: []
 


### PR DESCRIPTION
## Summary
- Add `persistence.volumes` values for declaring managed PVCs from deployment config
- Create `pvc.yaml` template that renders a PVC per volume entry
- Wire `volumeMounts` and `volumes` into `deployment.yaml` alongside existing raw passthrough
- Bump chart version to 1.1.0

Companion to [cnap-tech/cnap#98](https://github.com/cnap-tech/cnap/pull/98) which adds the UI for configuring persistence.

Ref CNAP-381

## Values schema
```yaml
persistence:
  enabled: true
  volumes:
    - name: data
      mountPath: /var/data
      size: 10Gi
      storageClassName: fast-ssd   # optional
      accessMode: ReadWriteOnce    # ReadWriteOnce | ReadWriteMany | ReadOnlyMany
```

## Test plan
- [x] `helm lint app/` passes
- [x] `helm template` with persistence renders PVC + volumeMount + volume
- [x] `helm template` without storageClassName omits it from PVC spec
- [x] `helm template` with persistence disabled renders no PVC
- [ ] Integration test in cnap repo passes after chart release (`state.helm-integration.test.ts`)